### PR TITLE
feat(crd-comments): implement create, read, and delete functionality for comments on articles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.2.0",
         "@prisma/client": "^6.12.0",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
@@ -24,7 +25,8 @@
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
-        "slugify": "^1.6.6"
+        "slugify": "^1.6.6",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -1937,6 +1939,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.4.tgz",
@@ -2706,6 +2714,39 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.0.tgz",
+      "integrity": "sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.21.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.3.tgz",
@@ -2905,6 +2946,13 @@
       "dependencies": {
         "@prisma/debug": "6.12.0"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -4931,7 +4979,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -8594,7 +8641,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11025,6 +11071,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "^6.12.0",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
@@ -35,7 +36,8 @@
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "slugify": "^1.6.6"
+    "slugify": "^1.6.6",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/prisma/migrations/20250724071756_add_comment/migration.sql
+++ b/prisma/migrations/20250724071756_add_comment/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE `Comment` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `body` VARCHAR(191) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    `articleId` INTEGER NOT NULL,
+    `authorId` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Comment` ADD CONSTRAINT `Comment_articleId_fkey` FOREIGN KEY (`articleId`) REFERENCES `Article`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Comment` ADD CONSTRAINT `Comment_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   updatedAt DateTime @updatedAt
 
   articles Article[]
+  comments Comment[]
 }
 
 model Article {
@@ -37,10 +38,23 @@ model Article {
   updatedAt   DateTime @updatedAt
   authorId    Int
   author      User     @relation(fields: [authorId], references: [id])
+
+  comments    Comment[]
 }
 
 model Tag {
   id       Int       @id @default(autoincrement())
   name     String    @unique
   articles Article[] @relation("ArticleTags")
+}
+
+model Comment {
+  id         Int      @id @default(autoincrement())
+  body       String
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  article    Article  @relation(fields: [articleId], references: [id])
+  articleId  Int
+  author     User     @relation(fields: [authorId], references: [id])
+  authorId   Int
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,12 +6,14 @@ import { PrismaModule } from 'prisma/prisma.module';
 import { ConfigModule } from '@nestjs/config';
 import { UserModule } from './user/user.module';
 import { ArticlesModule } from './articles/articles.module';
+import { CommentsModule } from './comments/comments.module';
 
 @Module({
   imports: [
     AuthModule,
     UserModule,
     ArticlesModule,
+    CommentsModule,
     PrismaModule,
     ConfigModule.forRoot({
       isGlobal: true,

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -1,7 +1,15 @@
 import {
-  Controller, Post, Get, Delete, Param, Body, Req, UseGuards,
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Param,
+  Body,
+  Req,
+  UseGuards,
   HttpCode,
   HttpStatus,
+  Query,
 } from '@nestjs/common';
 import { CommentsService } from './comments.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
@@ -17,18 +25,30 @@ export class CommentsController {
   @Post()
   async create(
     @Param('slug') slug: string,
-    @Body('comment') dto: CreateCommentDto,
+    @Body('comment') createCommentDto: CreateCommentDto,
     @Req() req: RequestUser,
-  ): Promise<CommentEntity> {
-    const comment = await this.commentsService.create(slug, req.user.sub, dto);
-    return new CommentEntity(comment);
+  ): Promise<{ comment: CommentEntity}> {
+    const comment = await this.commentsService.create(
+      slug,
+      req.user.sub,
+      createCommentDto,
+    );
+    return { comment: new CommentEntity(comment) };
   }
 
   @Get()
-  async findAll(@Param('slug') slug: string): Promise<{ comments: CommentEntity[] }> {
-    const comments = await this.commentsService.findByArticleSlug(slug);
+  async findAll(
+    @Param('slug') slug: string,
+    @Query('limit') limit = 10,
+    @Query('offset') offset = 0,
+  ): Promise<{ comments: CommentEntity[] }> {
+    const comments = await this.commentsService.findByArticleSlug(
+      slug,
+      +limit,
+      +offset,
+    );
     return {
-      comments: comments.map((c) => new CommentEntity(c).comment),
+      comments: comments.map((c) => new CommentEntity(c)),
     };
   }
 

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -54,13 +54,13 @@ export class CommentsController {
 
   @UseGuards(JwtAuthGuard)
   @Delete(':id')
-  @HttpCode(HttpStatus.NO_CONTENT)
+  @HttpCode(HttpStatus.OK)
   async remove(
     @Param('slug') slug: string,
     @Param('id') id: string,
     @Req() req: RequestUser,
   ) {
     await this.commentsService.remove(slug, +id, req.user.sub);
-    return;
+    return { message: 'Comment deleted successfully' };
   }
 }

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -1,0 +1,46 @@
+import {
+  Controller, Post, Get, Delete, Param, Body, Req, UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { CommentsService } from './comments.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { JwtAuthGuard } from 'src/auth/guards/auth.guard';
+import { RequestUser } from 'src/auth/interfaces/request-user.interface';
+import { CommentEntity } from './entities/comment.entity';
+
+@Controller('api/articles/:slug/comments')
+export class CommentsController {
+  constructor(private readonly commentsService: CommentsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  async create(
+    @Param('slug') slug: string,
+    @Body('comment') dto: CreateCommentDto,
+    @Req() req: RequestUser,
+  ): Promise<CommentEntity> {
+    const comment = await this.commentsService.create(slug, req.user.sub, dto);
+    return new CommentEntity(comment);
+  }
+
+  @Get()
+  async findAll(@Param('slug') slug: string): Promise<{ comments: CommentEntity[] }> {
+    const comments = await this.commentsService.findByArticleSlug(slug);
+    return {
+      comments: comments.map((c) => new CommentEntity(c).comment),
+    };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @Param('slug') slug: string,
+    @Param('id') id: string,
+    @Req() req: RequestUser,
+  ) {
+    await this.commentsService.remove(slug, +id, req.user.sub);
+    return;
+  }
+}

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CommentsController } from './comments.controller';
+import { CommentsService } from './comments.service';
+import { PrismaService } from 'prisma/prisma.service';
+
+@Module({
+  controllers: [CommentsController],
+  providers: [CommentsService, PrismaService],
+})
+export class CommentsModule {}

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { PrismaService } from 'prisma/prisma.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { Comment } from '@prisma/client';
@@ -7,13 +11,17 @@ import { Comment } from '@prisma/client';
 export class CommentsService {
   constructor(private prisma: PrismaService) {}
 
-  async create(slug: string, userId: number, dto: CreateCommentDto): Promise<Comment> {
+  async create(
+    slug: string,
+    userId: number,
+    createCommentDto: CreateCommentDto,
+  ): Promise<Comment> {
     const article = await this.prisma.article.findUnique({ where: { slug } });
     if (!article) throw new NotFoundException('Article not found');
 
     const comment = await this.prisma.comment.create({
       data: {
-        body: dto.body,
+        body: createCommentDto.body,
         authorId: userId,
         articleId: article.id,
       },
@@ -25,7 +33,11 @@ export class CommentsService {
     return comment;
   }
 
-  async findByArticleSlug(slug: string): Promise<Comment[]> {
+  async findByArticleSlug(
+    slug: string,
+    take = 10,
+    skip = 0,
+  ): Promise<Comment[]> {
     const article = await this.prisma.article.findUnique({
       where: { slug },
     });
@@ -35,6 +47,8 @@ export class CommentsService {
       where: { articleId: article.id },
       include: { author: true },
       orderBy: { createdAt: 'desc' },
+      take,
+      skip,
     });
 
     return comments;

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -6,6 +6,7 @@ import {
 import { PrismaService } from 'prisma/prisma.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { Comment } from '@prisma/client';
+import { DEFAULT_SKIP, DEFAULT_TAKE } from 'src/common/constants/pagination.constants';
 
 @Injectable()
 export class CommentsService {
@@ -35,8 +36,8 @@ export class CommentsService {
 
   async findByArticleSlug(
     slug: string,
-    take = 10,
-    skip = 0,
+    take = DEFAULT_TAKE,
+    skip = DEFAULT_SKIP,
   ): Promise<Comment[]> {
     const article = await this.prisma.article.findUnique({
       where: { slug },

--- a/src/comments/dto/create-comment.dto.ts
+++ b/src/comments/dto/create-comment.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateCommentDto {
+  @IsNotEmpty()
+  @IsString()
+  body: string;
+}

--- a/src/comments/entities/comment.entity.ts
+++ b/src/comments/entities/comment.entity.ts
@@ -1,18 +1,25 @@
 export class CommentEntity {
+  id: number;
+  createdAt: Date;
+  updatedAt: Date;
+  body: string;
+  author: {
+    username: string;
+    bio: string | null;
+    image: string | null;
+    following: boolean;
+  };
+
   constructor(comment: any) {
-    this.comment = {
-      id: comment.id,
-      createdAt: comment.createdAt,
-      updatedAt: comment.updatedAt,
-      body: comment.body,
-      author: {
-        username: comment.author.username,
-        bio: comment.author.bio,
-        image: comment.author.image,
-        following: false,
-      },
+    this.id = comment.id;
+    this.createdAt = comment.createdAt;
+    this.updatedAt = comment.updatedAt;
+    this.body = comment.body;
+    this.author = {
+      username: comment.author.username,
+      bio: comment.author.bio,
+      image: comment.author.image,
+      following: false,
     };
   }
-
-  comment: any;
 }

--- a/src/comments/entities/comment.entity.ts
+++ b/src/comments/entities/comment.entity.ts
@@ -1,0 +1,18 @@
+export class CommentEntity {
+  constructor(comment: any) {
+    this.comment = {
+      id: comment.id,
+      createdAt: comment.createdAt,
+      updatedAt: comment.updatedAt,
+      body: comment.body,
+      author: {
+        username: comment.author.username,
+        bio: comment.author.bio,
+        image: comment.author.image,
+        following: false,
+      },
+    };
+  }
+
+  comment: any;
+}

--- a/src/common/constants/pagination.constants.ts
+++ b/src/common/constants/pagination.constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_TAKE = 10;
+export const DEFAULT_SKIP = 0;


### PR DESCRIPTION
This pull request implements create, read, and delete functionalities for comments:

**1. Create comment (POST /api/articles/:slug/comments):**
- Validates input comment data
- Associates comment with authenticated user and target article
- Persists comment to database via Prisma
- Returns newly created comment info in expected API format

**2. Get comments by Article (GET /api/articles/:slug/comments):**
- Retrieves all comments associated with an article
- Returns list of comments with author info

**3. Delete comment (DELETE /api/articles/:slug/comments/:id):**
- Verifies ownership of the comment before deletion
- Deletes the comment from the database