### PR TITLE
Feat/favorite articles: implement favorite/unfavorite article functionality

### DIFF
--- a/prisma/migrations/20250725070109_add_favorite_articles_model/migration.sql
+++ b/prisma/migrations/20250725070109_add_favorite_articles_model/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE `FavoriteArticles` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `userId` INTEGER NOT NULL,
+    `articleId` INTEGER NOT NULL,
+
+    UNIQUE INDEX `FavoriteArticles_userId_articleId_key`(`userId`, `articleId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `FavoriteArticles` ADD CONSTRAINT `FavoriteArticles_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `FavoriteArticles` ADD CONSTRAINT `FavoriteArticles_articleId_fkey` FOREIGN KEY (`articleId`) REFERENCES `Article`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
 
   articles Article[]
   comments Comment[]
+  favorites FavoriteArticles[]
 }
 
 model Article {
@@ -40,6 +41,7 @@ model Article {
   author      User     @relation(fields: [authorId], references: [id])
 
   comments    Comment[]
+  favorites   FavoriteArticles[]
 }
 
 model Tag {
@@ -57,4 +59,14 @@ model Comment {
   articleId  Int
   author     User     @relation(fields: [authorId], references: [id])
   authorId   Int
+}
+
+model FavoriteArticles {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  article   Article  @relation(fields: [articleId], references: [id])
+  articleId Int
+
+  @@unique([userId, articleId])
 }

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -26,7 +26,7 @@ export class ArticlesController {
   @UseGuards(OptionalJwtAuthGuard)
   @Get(':slug')
   async findOne(@Param('slug') slug: string, @Req() req: RequestUser) {
-    const userId = req.user ? req.user.sub : undefined;
+    const userId = req.user?.sub;
     const article = await this.articlesService.findBySlug(slug, userId);
     return new ArticleEntity(article);
   }

--- a/src/articles/entities/article.entity.ts
+++ b/src/articles/entities/article.entity.ts
@@ -10,8 +10,8 @@ export class ArticleEntity {
       tagList: article.tagList.map((tag: Tag) => tag.name) || [],
       createdAt: article.createdAt,
       updatedAt: article.updatedAt,
-      favorited: false,
-      favoritesCount: 0,
+      favorited: article.favorited ?? false,
+      favoritesCount: article.favoritesCount ?? 0,
       author: {
         username: article.author.username,
         bio: article.author.bio,

--- a/src/auth/guards/optional-auth.guard.ts
+++ b/src/auth/guards/optional-auth.guard.ts
@@ -1,0 +1,9 @@
+import { Injectable, ExecutionContext } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard('jwt') {
+  handleRequest(err: any, user: any, info: any, context: ExecutionContext) {
+    return user || undefined;
+  }
+}


### PR DESCRIPTION
This pull request adds the functionality to favorite and unfavorite articles:
**1. Favorite an Article (POST /api/articles/:slug/favorite):**

- Authenticated users can favorite an article by slug
- Increments the favoritesCount of the article
- Persists the favorite relationship between user and article

**2. Unfavorite an Article (DELETE /api/articles/:slug/favorite):**

- Authenticated users can unfavorite a previously favorited article
- Decrements the favoritesCount
- Removes the favorite relationship from the database

**3. Article Response Enhancements:**

- Adds favorited: boolean field to article response (indicates whether the current user has favorited the article)
- Adds favoritesCount: number to reflect total favorite count per article